### PR TITLE
feature: modify to be capable of setting different datasets for train…

### DIFF
--- a/src/argument.py
+++ b/src/argument.py
@@ -14,6 +14,12 @@ def add_argument_common(parser: ArgumentParser) -> None:
         required=True,
         type=str.lower,
     )
+    parser.add_argument(
+        "--test_dataset_type",
+        choices=[x.name for x in DatasetType],
+        type=str.lower,
+        help="If not specified, use the same dataset type as the training dataset",
+    )
     parser.add_argument("--data_dir", required=True, default="data/")
     parser.add_argument(
         "--test_samples",
@@ -79,7 +85,7 @@ def add_argument_openai(parser: ArgumentParser) -> None:
     parser.add_argument(
         "--shot",
         help="Number of shots",
-        choices=[0, 3, 5, 10, 30, 50],
+        choices=[0, 1, 3, 5, 10, 30, 50],
         required=True,
         type=int,
     )

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -1,8 +1,8 @@
 import os
 from enum import Enum
-from typing import Optional
+from typing import Optional, List, Set, Tuple
 
-from datasets import Dataset, DatasetDict
+from datasets import Dataset, DatasetDict, concatenate_datasets
 
 from .fincausal import load_data_fincausal
 from .japanese import load_data_jpfin
@@ -11,20 +11,48 @@ from .reco import load_reco_dataset
 from .. import DatasetType, PlicitType, TaskType, assert_dataset_task_pair, logger
 
 
-def load_data(
+def get_columns_for_task(task_enum: Enum, dataset_enum: Enum) -> Set[str]:
+    if task_enum == TaskType.sequence_classification:
+        return {"example_id", "text", "labels"}
+    elif task_enum == TaskType.span_detection:
+        return {"example_id", "text", "tokens", "tags", "tagged_text"}
+    elif task_enum == TaskType.chain_classification:
+        if dataset_enum == DatasetType.reco:
+            return {"example_id", "events", "short_contexts", "labels"}
+    else:  # pragma: no cover
+        raise NotImplementedError()
+
+
+def _convert_example_ids(dataset: Dataset) -> Dataset:
+    """cast to int type to match the type when concatenating dataset"""
+    return dataset.map(
+        lambda example: {
+            "example_id": int(
+                "".join([char for char in str(example["example_id"]) if char.isdigit()])
+            )
+        }
+    )
+
+
+def _remove_unnecessary_columns(
+    ds_train: Dataset, ds_valid: Dataset, ds_test: Dataset, set_columns: Set[str]
+) -> Tuple[Dataset, Dataset, Dataset]:
+    ds_train = ds_train.remove_columns(list(set(ds_train.column_names) - set_columns))
+    ds_valid = ds_valid.remove_columns(list(set(ds_valid.column_names) - set_columns))
+    ds_test = ds_test.remove_columns(list(set(ds_test.column_names) - set_columns))
+    return ds_train, ds_valid, ds_test
+
+
+def load_dataset_for_corpus(
     task_enum: Enum,
     dataset_enum: Enum,
     sentencetype_enum: Enum,
     numcausal_enum: Enum,
     plicit_enum: Enum,
     data_dir: str,
-    test_samples: Optional[int] = None,
-    seed: int = 42,
-) -> DatasetDict:
-    assert_dataset_task_pair(dataset_enum=dataset_enum, task_enum=task_enum)
-    ds_train: Dataset
-    ds_valid: Dataset
-    ds_test: Dataset
+    seed: int,
+    set_columns: Set[str],
+) -> Tuple[Dataset, Dataset, Dataset]:
     if dataset_enum in (
         DatasetType.altlex,
         DatasetType.because,
@@ -34,39 +62,121 @@ def load_data(
         DatasetType.semeval,
     ):
         ds_train, ds_valid, ds_test = load_data_unicausal(
-            dataset_enum=dataset_enum,
-            task_enum=task_enum,
-            sentencetype_enum=sentencetype_enum,
-            numcausal_enum=numcausal_enum,
-            plicit_enum=plicit_enum,
-            data_dir=data_dir,
-            seed=seed,
+            dataset_enum,
+            task_enum,
+            sentencetype_enum,
+            numcausal_enum,
+            plicit_enum,
+            data_dir,
+            seed,
         )
+
     elif dataset_enum == DatasetType.fincausal:
         ds_train, ds_valid, ds_test = load_data_fincausal(
-            task_enum=task_enum,
-            data_dir=data_dir,
-            sentencetype_enum=sentencetype_enum,
-            plicit_enum=plicit_enum,
-            seed=seed,
+            task_enum, data_dir, sentencetype_enum, plicit_enum, seed
         )
+
     elif dataset_enum in (DatasetType.jpfinresults, DatasetType.jpnikkei):
         assert plicit_enum == PlicitType.all
         ds_train, ds_valid, ds_test = load_data_jpfin(
-            dataset_enum=dataset_enum,
-            task_enum=task_enum,
-            data_dir=data_dir,
-            numcausal_enum=numcausal_enum,
-            seed=seed,
+            dataset_enum, task_enum, data_dir, numcausal_enum, seed
         )
+
     elif dataset_enum == DatasetType.reco:
-        reco_dir: str = os.path.join(data_dir, "reco")
+        reco_dir = os.path.join(data_dir, "reco")
         assert os.path.isdir(reco_dir), f"{reco_dir} for ReCo data does not exist"
         ds_train = load_reco_dataset(os.path.join(reco_dir, "train.json"))
         ds_valid = load_reco_dataset(os.path.join(reco_dir, "dev.json"))
         ds_test = load_reco_dataset(os.path.join(reco_dir, "test.json"))
-    else:  # pragma: no cover
+
+    elif dataset_enum == DatasetType.all:
+        if task_enum == TaskType.sequence_classification:
+            train_dataset_list = [
+                "altlex",
+                "because",
+                "ctb",
+                "esl",
+                "pdtb",
+                "semeval",
+                "fincausal",
+            ]
+        elif task_enum == TaskType.span_detection:
+            train_dataset_list = ["altlex", "because", "pdtb", "fincausal"]
+        else:
+            raise NotImplementedError()
+
+        train_datasets, valid_datasets, test_datasets = [], [], []
+        for dataset in train_dataset_list:
+            _train, _valid, _test = load_dataset_for_corpus(
+                task_enum,
+                DatasetType[dataset],
+                sentencetype_enum,
+                numcausal_enum,
+                plicit_enum,
+                data_dir,
+                seed,
+                set_columns,
+            )
+            train_datasets.append(_train)
+            valid_datasets.append(_valid)
+            test_datasets.append(_test)
+
+        ds_train = concatenate_datasets(
+            [_convert_example_ids(ds) for ds in train_datasets]
+        ).shuffle(seed=seed)
+        ds_valid = concatenate_datasets(
+            [_convert_example_ids(ds) for ds in valid_datasets]
+        ).shuffle(seed=seed)
+        ds_test = concatenate_datasets(
+            [_convert_example_ids(ds) for ds in test_datasets]
+        ).shuffle(seed=seed)
+
+    else:
         raise NotImplementedError()
+
+    return _remove_unnecessary_columns(ds_train, ds_valid, ds_test, set_columns)
+
+
+def load_data(
+    task_enum: Enum,
+    dataset_enum: Enum,
+    sentencetype_enum: Enum,
+    numcausal_enum: Enum,
+    plicit_enum: Enum,
+    data_dir: str,
+    test_dataset_enum: Optional[Enum] = None,
+    test_samples: Optional[int] = None,
+    seed: int = 42,
+) -> DatasetDict:
+    if test_dataset_enum is None:
+        test_dataset_enum = dataset_enum
+    assert_dataset_task_pair(dataset_enum=dataset_enum, task_enum=task_enum)
+    assert_dataset_task_pair(dataset_enum=test_dataset_enum, task_enum=task_enum)
+    ds_train: Dataset
+    ds_valid: Dataset
+    ds_test: Dataset
+    set_columns: Set[str] = get_columns_for_task(task_enum, dataset_enum)
+
+    ds_train, ds_valid, _ = load_dataset_for_corpus(
+        task_enum,
+        dataset_enum,
+        sentencetype_enum,
+        numcausal_enum,
+        plicit_enum,
+        data_dir,
+        seed,
+        set_columns,
+    )
+    _, _, ds_test = load_dataset_for_corpus(
+        task_enum,
+        test_dataset_enum,
+        sentencetype_enum,
+        numcausal_enum,
+        plicit_enum,
+        data_dir,
+        seed,
+        set_columns,
+    )
 
     if test_samples is not None:
         if len(ds_test) >= test_samples:
@@ -83,18 +193,4 @@ def load_data(
         {"train": ds_train, "valid": ds_valid, "test": ds_test}
     )
     logger.info("# of samples: %s", dsd.num_rows)
-    # drop and assert columns
-    for key, ds_ in dsd.items():
-        set_columns: set[str]
-        if task_enum == TaskType.sequence_classification:
-            set_columns = {"example_id", "text", "labels"}
-        elif task_enum == TaskType.span_detection:
-            set_columns = {"example_id", "text", "tokens", "tags", "tagged_text"}
-        elif task_enum == TaskType.chain_classification:
-            if dataset_enum == DatasetType.reco:
-                set_columns = {"example_id", "events", "short_contexts", "labels"}
-        else:  # pragma: no cover
-            raise NotImplementedError()
-        dsd[key] = ds_.remove_columns(list(set(ds_.column_names) - set_columns))
-        assert set(dsd[key].column_names) == set_columns, dsd[key].column_names
     return dsd

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -61,6 +61,9 @@ def load_dataset_for_corpus(
         DatasetType.pdtb,
         DatasetType.semeval,
     ):
+        ds_train: Dataset
+        ds_valid: Dataset
+        ds_test: Dataset
         ds_train, ds_valid, ds_test = load_data_unicausal(
             dataset_enum,
             task_enum,
@@ -83,7 +86,7 @@ def load_dataset_for_corpus(
         )
 
     elif dataset_enum == DatasetType.reco:
-        reco_dir = os.path.join(data_dir, "reco")
+        reco_dir: str = os.path.join(data_dir, "reco")
         assert os.path.isdir(reco_dir), f"{reco_dir} for ReCo data does not exist"
         ds_train = load_reco_dataset(os.path.join(reco_dir, "train.json"))
         ds_valid = load_reco_dataset(os.path.join(reco_dir, "dev.json"))
@@ -102,7 +105,7 @@ def load_dataset_for_corpus(
             ]
         elif task_enum == TaskType.span_detection:
             train_dataset_list = ["altlex", "because", "pdtb", "fincausal"]
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError()
 
         train_datasets, valid_datasets, test_datasets = [], [], []
@@ -131,7 +134,7 @@ def load_dataset_for_corpus(
             [_convert_example_ids(ds) for ds in test_datasets]
         ).shuffle(seed=seed)
 
-    else:
+    else:  # pragma: no cover
         raise NotImplementedError()
 
     return _remove_unnecessary_columns(ds_train, ds_valid, ds_test, set_columns)

--- a/src/prediction/hf_encoder.py
+++ b/src/prediction/hf_encoder.py
@@ -177,6 +177,11 @@ def predict(args: Namespace) -> None:
     task_enum: Enum = TaskType[task_type]
     dataset_type: str = args.dataset_type
     dataset_enum: Enum = DatasetType[dataset_type]
+    test_dataset_type: Optional[str] = args.test_dataset_type
+    if test_dataset_type is None:
+        test_dataset_enum: Optional[Enum] = dataset_enum
+    else:
+        test_dataset_enum: Optional[Enum] = DatasetType[test_dataset_type]
     seed: int = args.seed
     model_name: str = args.model_name
     tokenizer_name: str = (
@@ -195,6 +200,7 @@ def predict(args: Namespace) -> None:
     dsd: DatasetDict = load_data(
         task_enum=task_enum,
         dataset_enum=dataset_enum,
+        test_dataset_enum=test_dataset_enum,
         sentencetype_enum=SentenceType[filter_num_sent],
         numcausal_enum=NumCausalType[filter_num_causal],
         plicit_enum=PlicitType[filter_plicit_type],
@@ -330,7 +336,8 @@ def predict(args: Namespace) -> None:
     logger.info("Best result: %s", best_result)
 
     filehead: str = (
-        datetime.datetime.now().strftime("%Y%m%d_%H%M_") + f"{task_type}_{dataset_type}"
+        datetime.datetime.now().strftime("%Y%m%d_%H%M_")
+        + f"{task_type}_{dataset_type}_{test_dataset_type}"
     )
     if (
         filter_num_sent == "all"
@@ -345,7 +352,7 @@ def predict(args: Namespace) -> None:
             filehead += f"_{filter_num_causal}"
         if filter_plicit_type != "all":
             filehead += f"_{filter_plicit_type}"
-    filehead += "_hf-encoder"
+    filehead += f"_hf-encoder_{seed}"
 
     result: list[str, Union[list[str], str]] = {
         **best_result,

--- a/src/prediction/hf_encoder.py
+++ b/src/prediction/hf_encoder.py
@@ -178,10 +178,11 @@ def predict(args: Namespace) -> None:
     dataset_type: str = args.dataset_type
     dataset_enum: Enum = DatasetType[dataset_type]
     test_dataset_type: Optional[str] = args.test_dataset_type
+    test_dataset_enum: Enum
     if test_dataset_type is None:
-        test_dataset_enum: Optional[Enum] = dataset_enum
+        test_dataset_enum = dataset_enum
     else:
-        test_dataset_enum: Optional[Enum] = DatasetType[test_dataset_type]
+        test_dataset_enum = DatasetType[test_dataset_type]
     seed: int = args.seed
     model_name: str = args.model_name
     tokenizer_name: str = (

--- a/src/setting.py
+++ b/src/setting.py
@@ -17,6 +17,7 @@ DatasetType: EnumMeta = Enum(
         "pdtb",
         "reco",
         "semeval",
+        "all",
     ),
 )
 TaskType: EnumMeta = Enum(
@@ -43,6 +44,7 @@ DatasetTaskPairs: tuple[tuple[Enum, tuple[Enum]]] = (
     (DatasetType.pdtb, (TaskType.sequence_classification, TaskType.span_detection)),
     (DatasetType.reco, (TaskType.chain_classification,)),
     (DatasetType.semeval, (TaskType.sequence_classification,)),
+    (DatasetType.all, (TaskType.sequence_classification, TaskType.span_detection)),
 )
 
 


### PR DESCRIPTION
Changed to allow training and testing to specify different datasets.

- If test_dataset_type is not specified, the same dataset as train is used for test
- train: valid: test division follows the rules of each dataset
- If "all" is specified, all English datasets available for <sequence classification|span detection> can be used for <train|test>